### PR TITLE
Jv trajectory motion

### DIFF
--- a/src/disco/build.mk
+++ b/src/disco/build.mk
@@ -66,6 +66,7 @@ core_robot += kernel/CanMipNode.o
 core_robot += kernel/CanMipMotor.o
 core_robot += middleware/motion/pid.o
 core_robot += middleware/motion/Motion.o
+core_robot += middleware/motion/MotionMoveState.o
 core_robot += middleware/motion/MotionDisabledState.o
 core_robot += middleware/motion/MotionTryEnableState.o
 core_robot += middleware/motion/MotionEnabledState.o

--- a/src/middleware/motion/Motion.cxx
+++ b/src/middleware/motion/Motion.cxx
@@ -335,6 +335,7 @@ void Motion::goTo(VectPlan dest, VectPlan cp, enum motion_way way, enum motion_t
 	m_wantedLinearParam = linearParam;
 	m_wantedAngularParam = angularParam;
 	m_status = MOTION_UPDATING_TRAJECTORY;
+	
 	xSemaphoreGive(m_mutex);
 }
 

--- a/src/middleware/motion/Motion.h
+++ b/src/middleware/motion/Motion.h
@@ -34,6 +34,7 @@ enum motion_state
 	MOTION_INTERRUPTING,         //!< arret en cours
 //	MOTION_BACK_TO_WALL,         //!< pas d'asservissement, les deux roues en marche arrière, pwm à x %. Arrêt quand le robot ne bouge plus
 	MOTION_MAX_STATE,
+	MOTION_UNKNOWN_STATE,	     //!< etat neutre permet d'indiquer que l'utilisateur ne veut pas changer d'état
 };
 
 enum motion_status
@@ -61,12 +62,12 @@ enum motion_wanted_state
 	MOTION_WANTED_STATE_TRAJECTORY,
 };
 */
-enum
+/*enum
 {
 	MOTION_ENABLE_WANTED_UNKNOWN = -1,
 	MOTION_ENABLE_WANTED_OFF = 0,
 	MOTION_ENABLE_WANTED_ON = 1
-};
+};*/
 
 enum motion_way
 {
@@ -178,6 +179,7 @@ class Motion
 		friend class MotionDisabledState;
 		friend class MotionTryEnableState;
 		friend class MotionEnabledState;
+		friend class MotionMoveState;
 		friend class MotionActuatorKinematicsState;
 		friend class MotionSpeedState;
 		friend class MotionTrajectoryState;

--- a/src/middleware/motion/Motion.h
+++ b/src/middleware/motion/Motion.h
@@ -52,7 +52,7 @@ enum motion_trajectory_step
 	MOTION_TRAJECTORY_STRAIGHT,
 	MOTION_TRAJECTORY_ROTATE,
 };
-
+/*
 enum motion_wanted_state
 {
 	MOTION_WANTED_STATE_UNKNOWN = 0,
@@ -60,7 +60,7 @@ enum motion_wanted_state
 	MOTION_WANTED_STATE_SPEED,
 	MOTION_WANTED_STATE_TRAJECTORY,
 };
-
+*/
 enum
 {
 	MOTION_ENABLE_WANTED_UNKNOWN = -1,
@@ -138,7 +138,7 @@ class Motion
 		Motion();
 		int init();
 
-		void getState(enum motion_state* state, enum motion_status* status, enum motion_trajectory_step* step, enum motion_wanted_state* wanted_state);
+		void getState(enum motion_state* state, enum motion_status* status, enum motion_trajectory_step* step, enum motion_state* wanted_state);
 
 		void enable(bool enable);
 
@@ -187,8 +187,8 @@ class Motion
 		float motionComputeTime(float ds, KinematicsParameters param);
 		unsigned int motionStateGenericPowerTransition(unsigned int currentState);
 
-		uint8_t m_enableWanted;
-		enum motion_wanted_state m_wantedState;
+		//uint8_t m_enableWanted;
+		enum motion_state m_wantedState;
 		enum motion_status m_status;
 		enum motion_trajectory_step m_trajStep;
 		struct motion_cmd_set_actuator_kinematics_arg m_wantedKinematics; // cinematique desiree (mode MOTION_ACTUATOR_KINEMATICS)

--- a/src/middleware/motion/MotionActuatorKinematicsState.cxx
+++ b/src/middleware/motion/MotionActuatorKinematicsState.cxx
@@ -1,10 +1,18 @@
 #include "MotionActuatorKinematicsState.h"
 
 MotionActuatorKinematicsState::MotionActuatorKinematicsState() :
-	StateMachineState("MOTION_ACTUATOR_KINEMATICS")
+	MotionMoveState("MOTION_ACTUATOR_KINEMATICS",MOTION_ACTUATOR_KINEMATICS)
 {
 
 }
+void MotionActuatorKinematicsState::entry(void* data)
+{
+	Motion* m = (Motion*) data;
+	//Satisfaction de la volonte operateur
+	m->m_wantedState = MOTION_UNKNOWN_STATE;
+
+}
+
 
 void MotionActuatorKinematicsState::run(void* data)
 {
@@ -26,8 +34,3 @@ void MotionActuatorKinematicsState::run(void* data)
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionActuatorKinematicsState::transition(void* data)
-{
-	Motion* m = (Motion*) data;
-	return m->motionStateGenericPowerTransition(currentState);
-}

--- a/src/middleware/motion/MotionActuatorKinematicsState.cxx
+++ b/src/middleware/motion/MotionActuatorKinematicsState.cxx
@@ -26,7 +26,7 @@ void MotionActuatorKinematicsState::run(void* data)
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionActuatorKinematicsState::transition(void* data, unsigned int currentState)
+unsigned int MotionActuatorKinematicsState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
 	return m->motionStateGenericPowerTransition(currentState);

--- a/src/middleware/motion/MotionActuatorKinematicsState.h
+++ b/src/middleware/motion/MotionActuatorKinematicsState.h
@@ -6,13 +6,13 @@
 //! @author Atlantronic
 
 #include "Motion.h"
-
-class MotionActuatorKinematicsState : public StateMachineState
+#include "MotionMoveState.h"
+class MotionActuatorKinematicsState : public MotionMoveState
 {
 	public:
 		MotionActuatorKinematicsState();
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		void entry(void* data);
 };
 
 #endif

--- a/src/middleware/motion/MotionDisabledState.cxx
+++ b/src/middleware/motion/MotionDisabledState.cxx
@@ -2,18 +2,22 @@
 #include "kernel/driver/power.h"
 
 MotionDisabledState::MotionDisabledState() :
-	StateMachineState("MOTION_DISABLED")
+	StateMachineState("MOTION_DISABLED",MOTION_DISABLED)
 {
 
 }
 
 void MotionDisabledState::entry(void* data)
 {
-	Motion* m = (Motion*) data;
+//Par defaut quand on entre dans un nouvel etat on ne veut pas aller plus loin
+	m->m_wantedState = MOTION_UNKNOWN_STATE;
 #ifndef MOTION_AUTO_ENABLE
-	m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
+	//Par defaut on ne fait rien
+//	m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
 #else
-	m->m_enableWanted = MOTION_ENABLE_WANTED_ON;
+	//Si on veut aller dans l'état AUTO_ENABLE cad => on veut aller dans l'etat ENABLE pas besoin de variables suplémentaires
+	Motion* m = (Motion*) data;
+	m->m_wantedState  = MOTION_ENABLE_STATE;
 #endif
 }
 
@@ -28,26 +32,33 @@ void MotionDisabledState::run(void* data)
 	}
 }
 
-unsigned int MotionDisabledState::transition(void* data, unsigned int currentState)
+unsigned int MotionDisabledState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
-#ifndef MOTION_AUTO_ENABLE
-	if( power_get() )
-	{
-		// puissance desactivee
-		m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
-	}
-#else
-	if( ! power_get() )
-	{
-		m->m_enableWanted = MOTION_ENABLE_WANTED_ON;
-	}
-#endif
 
-	if( m->m_enableWanted == MOTION_ENABLE_WANTED_ON && ! power_get() )
+//#ifndef MOTION_AUTO_ENABLE
+	//Cas d'erreur
+	// Bah on ne fait rien car c'est dans cette Etat qu'on étient le moteur pas la peine de faire quelque chose
+	//if( power_get() )
+	//{
+		// puissance desactivee
+	//	m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
+	//}
+//#else
+///  Même si on pas de puissance 
+///   Cette partie est inutile car elle est géré dans la méthode d'entry
+///	if( ! power_get() )
+//	{
+//		m->m_enableWanted = MOTION_ENABLE_WANTED_ON;
+//	}
+//#endif
+	///Quand on allume les moteur c'est pour aller dans l'etat Enable (c'est évident non????? ) on ne garde pas la motion allumage des moteurs ou on change le nom MOTION_TRY_ENABLE => MOTION_TRY_ENABLE_MOTOR
+	///Même si on a de la puissance on veut changer d'état on change d'état que veut tu faire d'autre ??? 
+	//Sinon c'est un cas de blocage on restera toujours dans le même état
+	if( m->m_wantedState == MOTION_ENABLE &&  !power_get() )
 	{
 		return MOTION_TRY_ENABLE;
 	}
 
-	return currentState;
+	return m_stateId;
 }

--- a/src/middleware/motion/MotionDisabledState.cxx
+++ b/src/middleware/motion/MotionDisabledState.cxx
@@ -9,6 +9,7 @@ MotionDisabledState::MotionDisabledState() :
 
 void MotionDisabledState::entry(void* data)
 {
+	Motion* m = (Motion*) data;
 //Par defaut quand on entre dans un nouvel etat on ne veut pas aller plus loin
 	m->m_wantedState = MOTION_UNKNOWN_STATE;
 #ifndef MOTION_AUTO_ENABLE
@@ -16,8 +17,7 @@ void MotionDisabledState::entry(void* data)
 //	m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
 #else
 	//Si on veut aller dans l'état AUTO_ENABLE cad => on veut aller dans l'etat ENABLE pas besoin de variables suplémentaires
-	Motion* m = (Motion*) data;
-	m->m_wantedState  = MOTION_ENABLE_STATE;
+	m->m_wantedState  = MOTION_ENABLED;
 #endif
 }
 
@@ -38,7 +38,7 @@ unsigned int MotionDisabledState::transition(void* data)
 
 //#ifndef MOTION_AUTO_ENABLE
 	//Cas d'erreur
-	// Bah on ne fait rien car c'est dans cette Etat qu'on étient le moteur pas la peine de faire quelque chose
+	// Bah on ne fait rien car c'est dans cette Etat qu'on étient le moteur pas la peine de faire quelque chose que de rester dans le meme etat
 	//if( power_get() )
 	//{
 		// puissance desactivee
@@ -55,7 +55,7 @@ unsigned int MotionDisabledState::transition(void* data)
 	///Quand on allume les moteur c'est pour aller dans l'etat Enable (c'est évident non????? ) on ne garde pas la motion allumage des moteurs ou on change le nom MOTION_TRY_ENABLE => MOTION_TRY_ENABLE_MOTOR
 	///Même si on a de la puissance on veut changer d'état on change d'état que veut tu faire d'autre ??? 
 	//Sinon c'est un cas de blocage on restera toujours dans le même état
-	if( m->m_wantedState == MOTION_ENABLE &&  !power_get() )
+	if( m->m_wantedState == MOTION_ENABLED &&  !power_get() )
 	{
 		return MOTION_TRY_ENABLE;
 	}

--- a/src/middleware/motion/MotionDisabledState.h
+++ b/src/middleware/motion/MotionDisabledState.h
@@ -13,7 +13,7 @@ class MotionDisabledState : public StateMachineState
 		MotionDisabledState();
 		virtual void entry(void* data);
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		virtual unsigned int transition(void* data);
 };
 
 #endif

--- a/src/middleware/motion/MotionEnabledState.cxx
+++ b/src/middleware/motion/MotionEnabledState.cxx
@@ -1,5 +1,5 @@
 #include "MotionEnabledState.h"
-
+#include "kernel/log.h"
 #include "kernel/driver/power.h"
 
 MotionEnabledState::MotionEnabledState() :
@@ -20,6 +20,8 @@ void MotionEnabledState::entry(void* data)
 //	}
 	//Satisfaction de la volonte operateur ou de la volonte automatique
 	m->m_wantedState = MOTION_UNKNOWN_STATE;
+
+		log_format(LOG_INFO, "WantedState %d ",m->m_wantedState);
 }
 
 void MotionEnabledState::run(void* data)
@@ -46,17 +48,18 @@ unsigned int MotionEnabledState::transition(void* data)
 
 	///if( power_get() || ! all_op_enable || m->m_enableWanted == MOTION_ENABLE_WANTED_OFF )
 	//Si Aucun moteur actif 
-	if(power_get() || ! all_op_enable )
+	if(power_get() || !all_op_enable )
 	{
 		return MOTION_DISABLED;
 	}
 
 	//Action Operateur de passer de changer d'etat dans les etat suivant on retourne l'etat MotionEnable
-	if( m->m_wantedState == MOTION_ACTUATOR_KINEMATICS
+	if( m->m_wantedState == MOTION_DISABLED 
+	 || m->m_wantedState == MOTION_ACTUATOR_KINEMATICS
 	 || m->m_wantedState == MOTION_SPEED
-	 || m->m_wantedState == MOTION_TRAJECTORY
-	 || m->m_wantedState == MOTION_DISABLED)
+	 || m->m_wantedState == MOTION_TRAJECTORY)
 	{
+		log_format(LOG_INFO, "WantedState %d ",m->m_wantedState);
 		return m->m_wantedState; 
 	}
 

--- a/src/middleware/motion/MotionEnabledState.cxx
+++ b/src/middleware/motion/MotionEnabledState.cxx
@@ -3,7 +3,7 @@
 #include "kernel/driver/power.h"
 
 MotionEnabledState::MotionEnabledState() :
-	StateMachineState("MOTION_ENABLED")
+	StateMachineState("MOTION_ENABLED",MOTION_ENABLED)
 {
 
 }
@@ -11,13 +11,15 @@ MotionEnabledState::MotionEnabledState() :
 void MotionEnabledState::entry(void* data)
 {
 	Motion* m = (Motion*) data;
-	if( m->m_enableWanted == MOTION_ENABLE_WANTED_ON )
-	{
-#ifndef MOTION_AUTO_ENABLE
-		m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
-#endif
-	}
-	m->m_wantedState = MOTION_WANTED_STATE_UNKNOWN;
+///	Code MORT
+//	if( m->m_enableWanted == MOTION_ENABLE_WANTED_ON )
+//	{
+//#ifndef MOTION_AUTO_ENABLE
+//		m->m_enableWanted = MOTION_ENABLE_WANTED_UNKNOWN;
+//#endif
+//	}
+	//Satisfaction de la volonte operateur ou de la volonte automatique
+	m->m_wantedState = MOTION_UNKNOWN_STATE;
 }
 
 void MotionEnabledState::run(void* data)
@@ -32,7 +34,7 @@ void MotionEnabledState::run(void* data)
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionEnabledState::transition(void* data, unsigned int currentState)
+unsigned int MotionEnabledState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
 	bool all_op_enable = true;
@@ -42,25 +44,22 @@ unsigned int MotionEnabledState::transition(void* data, unsigned int currentStat
 		all_op_enable &= m->m_canMotor[i].is_op_enable();
 	}
 
-	if( power_get() || ! all_op_enable || m->m_enableWanted == MOTION_ENABLE_WANTED_OFF )
+	///if( power_get() || ! all_op_enable || m->m_enableWanted == MOTION_ENABLE_WANTED_OFF )
+	//Si Aucun moteur actif 
+	if(power_get() || ! all_op_enable )
 	{
 		return MOTION_DISABLED;
 	}
 
-	switch(m->m_wantedState)
+	//Action Operateur de passer de changer d'etat dans les etat suivant on retourne l'etat MotionEnable
+	if( m->m_wantedState == MOTION_ACTUATOR_KINEMATICS
+	 || m->m_wantedState == MOTION_SPEED
+	 || m->m_wantedState == MOTION_TRAJECTORY
+	 || m->m_wantedState == MOTION_DISABLED)
 	{
-		case MOTION_WANTED_STATE_ACTUATOR_KINEMATICS:
-			return MOTION_ACTUATOR_KINEMATICS;
-			break;
-		case MOTION_WANTED_STATE_TRAJECTORY:
-			return MOTION_TRAJECTORY;
-			break;
-		case MOTION_WANTED_STATE_SPEED:
-			return MOTION_SPEED;
-		case MOTION_WANTED_STATE_UNKNOWN:
-		default:
-			break;
+		return m->m_wantedState; 
 	}
 
-	return currentState;
+	//SInon dans les autres cas on change d'etat
+	return m_stateId;
 }

--- a/src/middleware/motion/MotionEnabledState.h
+++ b/src/middleware/motion/MotionEnabledState.h
@@ -13,7 +13,7 @@ class MotionEnabledState : public StateMachineState
 		MotionEnabledState();
 		virtual void entry(void* data);
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		virtual unsigned int transition(void* data);
 };
 
 #endif

--- a/src/middleware/motion/MotionInterruptingState.cxx
+++ b/src/middleware/motion/MotionInterruptingState.cxx
@@ -1,7 +1,7 @@
 #include "MotionInterruptingState.h"
 
 MotionInterruptingState::MotionInterruptingState() :
-	StateMachineState("MOTION_INTERRUPTING")
+	MotionMoveState("MOTION_INTERRUPTING",MOTION_INTERRUPTING)
 {
 
 }
@@ -16,9 +16,11 @@ void MotionInterruptingState::run(void* data)
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionInterruptingState::transition(void* data, unsigned int currentState)
+unsigned int MotionInterruptingState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
+	
+
 	for(int i = 0; i < CAN_MOTOR_MAX; i++ )
 	{
 		if( m->m_canMotor[i].is_in_motion() )
@@ -26,9 +28,9 @@ unsigned int MotionInterruptingState::transition(void* data, unsigned int curren
 			return MOTION_INTERRUPTING;
 		}
 	}
-
-	unsigned int newState = m->motionStateGenericPowerTransition(currentState);
-	if( newState != currentState )
+	
+	unsigned int newState = MotionMoveState::transition(data);
+	if( newState == MOTION_DISABLED )
 	{
 		return newState;
 	}

--- a/src/middleware/motion/MotionInterruptingState.h
+++ b/src/middleware/motion/MotionInterruptingState.h
@@ -7,12 +7,13 @@
 
 #include "Motion.h"
 
-class MotionInterruptingState : public StateMachineState
+#include "MotionMoveState.h"
+class MotionInterruptingState : public MotionMoveState
 {
 	public:
 		MotionInterruptingState();
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		virtual unsigned int transition(void* data);
 };
 
 #endif

--- a/src/middleware/motion/MotionMoveState.cxx
+++ b/src/middleware/motion/MotionMoveState.cxx
@@ -1,0 +1,39 @@
+#include "MotionMoveState.h"
+#include "kernel/driver/power.h"	
+
+MotionMoveState::MotionMoveState(const char* name,unsigned int stateId):StateMachineState(name,stateId)
+{
+}
+
+
+unsigned int MotionMoveState::transition(void* data)
+{
+
+	Motion* m = (Motion*) data;
+
+	bool all_op_enable = true;
+
+	for(int i = 0; i < CAN_MOTOR_MAX; i++)
+	{
+		all_op_enable &= m->m_canMotor[i].is_op_enable();
+	}
+	///En gros on veut éteindre les moteur cad passer dans l'etat DISABLE
+	/// On par en DIsable si pas de puissance dans les moteur ou on veut eteindre les moteur en partant en DISABLE
+	if( power_get() || ! all_op_enable || m->m_wantedState == MOTION_DISABLED)
+	{
+		return MOTION_DISABLED;
+	}
+
+	//On rentre dans ce If que dans l'état DISABLE ou TRY_ENABLE ou MOTION_ENABLE
+	//Or cette méthode est appellée seulement par les ETATs autres que ces trois derniers....
+	//Donc Code mort à supprimer
+//	if( m_wantedState == MOTION_ENABLED && currentState != MOTION_ACTUATOR_KINEMATICS &&
+//		currentState != MOTION_SPEED && currentState != MOTION_TRAJECTORY && currentState != MOTION_INTERRUPTING)
+//	{
+//		return MOTION_ENABLED;
+//	}
+
+	return m_stateId;
+}
+
+

--- a/src/middleware/motion/MotionMoveState.h
+++ b/src/middleware/motion/MotionMoveState.h
@@ -1,0 +1,18 @@
+#ifndef MOTION_MOVE_STATE_H
+#define MOTION_MOVE_STATE_H
+
+//! @file MotionMoveState.h
+//! @brief Etat MotionMove
+//! @author Atlantronic
+
+#include "Motion.h"
+
+class MotionMoveState : public StateMachineState
+{
+	public:
+		MotionMoveState(const char* name,unsigned int stateId);
+		virtual void run(void* data){};
+		virtual unsigned int transition(void* data);
+};
+
+#endif

--- a/src/middleware/motion/MotionSpeedState.cxx
+++ b/src/middleware/motion/MotionSpeedState.cxx
@@ -5,15 +5,20 @@
 #include "kernel/kinematics_model/kinematics_model.h"
 
 MotionSpeedState::MotionSpeedState() :
-	StateMachineState("MOTION_SPEED")
+	MotionMoveState("MOTION_SPEED",MOTION_SPEED)
 {
 
 }
 
 void MotionSpeedState::entry(void* data)
 {
+
 	Motion* m = (Motion*) data;
 	m->m_status = MOTION_IN_MOTION;
+
+	//Satisfaction de la volonte operateur
+	m->m_wantedState = MOTION_UNKNOWN_STATE;
+
 	log(LOG_INFO, "IN_MOTION");
 }
 
@@ -24,8 +29,3 @@ void MotionSpeedState::run(void* data)
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionSpeedState::transition(void* data, unsigned int currentState)
-{
-	Motion* m = (Motion*) data;
-	return m->motionStateGenericPowerTransition(currentState);
-}

--- a/src/middleware/motion/MotionSpeedState.h
+++ b/src/middleware/motion/MotionSpeedState.h
@@ -7,13 +7,13 @@
 
 #include "Motion.h"
 
-class MotionSpeedState : public StateMachineState
+#include "MotionMoveState.h"
+class MotionSpeedState : public MotionMoveState
 {
 	public:
 		MotionSpeedState();
 		virtual void entry(void* data);
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
 };
 
 #endif

--- a/src/middleware/motion/MotionTrajectoryState.cxx
+++ b/src/middleware/motion/MotionTrajectoryState.cxx
@@ -320,11 +320,11 @@ error:
 	m->motionUpdateMotors();
 }
 
-unsigned int MotionTrajectoryState::transition(void* data, unsigned int currentState)
+unsigned int MotionTrajectoryState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
 	unsigned int newState = m->motionStateGenericPowerTransition(currentState);
-	if( newState != currentState || m->m_status != MOTION_IN_MOTION)
+	if( newState != m_stateId || m->m_status != MOTION_IN_MOTION)
 	{
 		return MOTION_INTERRUPTING;
 	}

--- a/src/middleware/motion/MotionTrajectoryState.h
+++ b/src/middleware/motion/MotionTrajectoryState.h
@@ -6,14 +6,16 @@
 //! @author Atlantronic
 
 #include "Motion.h"
-
-class MotionTrajectoryState : public StateMachineState
+#include "MotionMoveState.h"
+class MotionTrajectoryState : public MotionMoveState
 {
 	public:
 		MotionTrajectoryState();
 		virtual void entry(void* data);
 		virtual void run(void* data);
 		virtual unsigned int transition(void* data);
+	protected:
+		void Stop(Motion* m);
 };
 
 #endif

--- a/src/middleware/motion/MotionTrajectoryState.h
+++ b/src/middleware/motion/MotionTrajectoryState.h
@@ -13,7 +13,7 @@ class MotionTrajectoryState : public StateMachineState
 		MotionTrajectoryState();
 		virtual void entry(void* data);
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		virtual unsigned int transition(void* data);
 };
 
 #endif

--- a/src/middleware/motion/MotionTryEnableState.cxx
+++ b/src/middleware/motion/MotionTryEnableState.cxx
@@ -24,7 +24,8 @@ unsigned int MotionTryEnableState::transition(void* data)
 	Motion* m = (Motion*) data;
 	bool all_op_enable = true;
 
-	if( power_get() || m->m_enableWanted == MOTION_ENABLE_WANTED_OFF )
+	//Volonte de l'utilisateur de couper l'etat ou pas de puissance
+	if( power_get() || m->m_wantedState == MOTION_DISABLED )
 	{
 		// puissance desactivee
 		return MOTION_DISABLED;
@@ -41,5 +42,5 @@ unsigned int MotionTryEnableState::transition(void* data)
 		return MOTION_ENABLED;
 	}
 
-	return currentState;
+	return m_stateId;
 }

--- a/src/middleware/motion/MotionTryEnableState.cxx
+++ b/src/middleware/motion/MotionTryEnableState.cxx
@@ -3,7 +3,7 @@
 #include "kernel/driver/power.h"
 
 MotionTryEnableState::MotionTryEnableState() :
-	StateMachineState("MOTION_TRY_ENABLE")
+	StateMachineState("MOTION_TRY_ENABLE",MOTION_TRY_ENABLE)
 {
 
 }
@@ -19,7 +19,7 @@ void MotionTryEnableState::run(void* data)
 	}
 }
 
-unsigned int MotionTryEnableState::transition(void* data, unsigned int currentState)
+unsigned int MotionTryEnableState::transition(void* data)
 {
 	Motion* m = (Motion*) data;
 	bool all_op_enable = true;

--- a/src/middleware/motion/MotionTryEnableState.h
+++ b/src/middleware/motion/MotionTryEnableState.h
@@ -12,7 +12,7 @@ class MotionTryEnableState : public StateMachineState
 	public:
 		MotionTryEnableState();
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
+		virtual unsigned int transition(void* data);
 };
 
 #endif

--- a/src/middleware/state_machine/StateMachine.cxx
+++ b/src/middleware/state_machine/StateMachine.cxx
@@ -6,8 +6,10 @@ StateMachine::StateMachine(StateMachineState** states, unsigned int size, void* 
 	m_data = data;
 	m_states = states;
 	m_size = size;
+
+	//Initialisation pour effectuer l'entry du premier Etat (0)
 	m_currentStateId = 0;
-	m_lastStateId = m_size;
+	m_lastStateId = m_size;	
 }
 
 int StateMachine::execute()

--- a/src/middleware/state_machine/StateMachine.cxx
+++ b/src/middleware/state_machine/StateMachine.cxx
@@ -26,18 +26,18 @@ int StateMachine::execute()
 
 	m_states[m_currentStateId]->run(m_data);
 
-	unsigned int wantedStateId = m_states[m_currentStateId]->transition(m_data, m_currentStateId);
-	if( wantedStateId >= m_size)
+	unsigned int nextStateId = m_states[m_currentStateId]->transition(m_data);
+	if( nextStateId >= m_size)
 	{
 		log_format(LOG_ERROR, "invalid state machine transition to id %d >= size %d", m_currentStateId, m_size);
 		return -1;
 	}
 
-	if( wantedStateId != m_currentStateId )
+	if( nextStateId != m_currentStateId )
 	{
-		m_currentStateId = wantedStateId;
+		m_currentStateId = nextStateId;
 		log_format(LOG_INFO, "%s", m_states[m_currentStateId]->m_name);
-		m_states[m_currentStateId]->entry(m_data);
+		m_states[m_currentStateId]->out(m_data);
 		m_lastStateId = m_currentStateId;
 	}
 

--- a/src/middleware/state_machine/StateMachine.cxx
+++ b/src/middleware/state_machine/StateMachine.cxx
@@ -22,10 +22,16 @@ int StateMachine::execute()
 
 	if( m_lastStateId != m_currentStateId)
 	{
+		log_format(LOG_INFO, "%s", m_states[m_currentStateId]->m_name);
+		log_format(LOG_ERROR, "Entry state %d ol state %d", m_currentStateId, m_lastStateId);
 		m_states[m_currentStateId]->entry(m_data);
 		m_lastStateId = m_currentStateId;
 	}
-
+	int index = 0;
+	while(index != 100) 
+	{
+		index++;
+	}
 	m_states[m_currentStateId]->run(m_data);
 
 	unsigned int nextStateId = m_states[m_currentStateId]->transition(m_data);
@@ -37,10 +43,11 @@ int StateMachine::execute()
 
 	if( nextStateId != m_currentStateId )
 	{
-		m_currentStateId = nextStateId;
-		log_format(LOG_INFO, "%s", m_states[m_currentStateId]->m_name);
 		m_states[m_currentStateId]->out(m_data);
 		m_lastStateId = m_currentStateId;
+		m_currentStateId = nextStateId;
+		
+		
 	}
 
 	return 0;

--- a/src/middleware/state_machine/StateMachineState.cxx
+++ b/src/middleware/state_machine/StateMachineState.cxx
@@ -1,8 +1,9 @@
 #include "StateMachineState.h"
 
-StateMachineState::StateMachineState(const char* name)
+StateMachineState::StateMachineState(const char* name,unsigned int stateId)
 {
 	m_name = name;
+	m_stateId = stateId;
 }
 
 void StateMachineState::entry(void* /*data*/)
@@ -15,7 +16,13 @@ void StateMachineState::run(void* /*data*/)
 
 }
 
-unsigned int StateMachineState::transition(void* /*data*/, unsigned int currentState)
+void StateMachineState::out(void* /*data*/)
 {
-	return currentState;
+
+}
+
+
+unsigned int StateMachineState::transition(void* /*data*/)
+{
+	return m_stateId;
 }

--- a/src/middleware/state_machine/StateMachineState.h
+++ b/src/middleware/state_machine/StateMachineState.h
@@ -6,11 +6,12 @@
 class StateMachineState
 {
 	public:
-		StateMachineState(const char* name);
+		StateMachineState(const char* name,unsigned int stateId);
 		virtual void entry(void* data);
 		virtual void run(void* data);
-		virtual unsigned int transition(void* data, unsigned int currentState);
-
+		virtual void out(void* data);
+		virtual unsigned int transition(void* data);
+		unsigned int m_stateId;
 		const char* m_name;
 };
 

--- a/src/middleware/trajectory/Trajectory.cxx
+++ b/src/middleware/trajectory/Trajectory.cxx
@@ -77,10 +77,9 @@ void Trajectory::trajectory_task(void* arg)
 void Trajectory::trajectoryTask()
 {
 	uint32_t wake_time = 0;
-	enum motion_state motion_state;
+	enum motion_state motion_state, motion_wanted_state;
 	enum motion_status motion_status;
 	enum motion_trajectory_step motion_traj_step;
-	enum motion_wanted_state motion_wanted_state;
 
 	while(1)
 	{
@@ -139,7 +138,7 @@ void Trajectory::trajectoryTask()
 				}
 				break;
 			case TRAJECTORY_STATE_MOVE_TO_DEST:
-				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_WANTED_STATE_UNKNOWN )
+				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_UNKNOWN_STATE )
 				{
 					VectPlan dest = m_dest;
 					VectPlan u = m_dest - m_pos;
@@ -164,7 +163,7 @@ void Trajectory::trajectoryTask()
 				}
 				break;
 			case TRAJECTORY_STATE_USING_GRAPH:
-				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_WANTED_STATE_UNKNOWN )
+				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_UNKNOWN_STATE )
 				{
 					if( m_graphWayId < m_graph.m_wayCount - 1 )
 					{
@@ -187,7 +186,7 @@ void Trajectory::trajectoryTask()
 				}
 				break;
 			case TRAJECTORY_STATE_MOVE_TO_GRAPH:
-				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_WANTED_STATE_UNKNOWN)
+				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_UNKNOWN_STATE)
 				{
 					m_trajectoryState = TRAJECTORY_STATE_USING_GRAPH;
 					int i = m_graph.m_way[0];

--- a/src/middleware/trajectory/Trajectory.cxx
+++ b/src/middleware/trajectory/Trajectory.cxx
@@ -138,11 +138,13 @@ void Trajectory::trajectoryTask()
 				}
 				break;
 			case TRAJECTORY_STATE_MOVE_TO_DEST:
+
 				if( motion_state == MOTION_ENABLED && motion_wanted_state == MOTION_UNKNOWN_STATE )
 				{
 					VectPlan dest = m_dest;
 					VectPlan u = m_dest - m_pos;
 					float ds = u.norm();
+					log_format(LOG_INFO, "Move to dest");
 					motion_trajectory_type traj_type = MOTION_AXIS_XYA;
 					if( fabsf(ds) > EPSILON )
 					{


### PR DESCRIPTION
On gagne en d'espace mémoire oqp et en performance sur les transitions de trajectory, kinematics ...
On supprime un enum, on diminue la taille du fichier motion
